### PR TITLE
improve partitions merging algorithm

### DIFF
--- a/lib/mergeSorter.js
+++ b/lib/mergeSorter.js
@@ -15,24 +15,39 @@ class MergeSorter extends Sorter {
      * 
      * @param {array} leftPartition
      * @param {array} rightPartition
-     * @param {merged} memoize the merged sorted partition
      *
-     * @return {array} the sorted partition
+     * @return {array} the merged and sorted partition
      */
-    merge(leftPartition, rightPartition, merged = []) {
-        if (leftPartition.length === 0) {
-            return merged.concat(rightPartition);
+    merge(leftPartition, rightPartition) {
+        let leftIndex = 0,
+            rightIndex = 0,
+            i = 0, merged = [],
+            leftLength = leftPartition.length,
+            rightLength = rightPartition.length;
+
+        while (leftIndex < leftLength || rightIndex < rightLength) {
+            if (leftIndex === leftLength) {
+                for (i = rightIndex; i < rightLength; i++) {
+                    merged.push(rightPartition[rightIndex]);
+                    rightIndex++;
+                }
+            }
+            else if (rightIndex === rightLength) {
+                for (i = leftIndex; i < leftLength; i++) {
+                    merged.push(leftPartition[leftIndex]);
+                    leftIndex++;
+                }
+            }
+            else if (leftPartition[leftIndex] < rightPartition[rightIndex]) {
+                merged.push(leftPartition[leftIndex]);
+                leftIndex++;
+            }
+            else {
+                merged.push(rightPartition[rightIndex]);
+                rightIndex++;
+            }     
         }
-        else if (rightPartition.length === 0) {
-            return merged.concat(leftPartition);
-        }
-        else if (leftPartition[0] < rightPartition[0]) {
-            merged.push(leftPartition.shift());
-        }
-        else {
-            merged.push(rightPartition.shift());
-        }
-        return this.merge(leftPartition, rightPartition, merged);
+        return merged;
     }
 
     /* 


### PR DESCRIPTION
Improve merge sort algrithm
---

* recursive call in merging partitions is causing a `Maximum call stack size exceeded` error for big size arrays. so I replaced that with a while loop.
* Remove partitions mutation to improve performance and replace that with a tracking index on the merged element.